### PR TITLE
Fixes for index.html

### DIFF
--- a/demo/glyflist/index.html
+++ b/demo/glyflist/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8" />
 <title>ttf.js Demo - Glyph List</title>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script type="text/javascript" src="../../vendor/jdataview.js"></script>
 <script type="text/javascript" src="../../src/ttf.js"></script>
 <script type="text/javascript" src="./glyflist.js"></script>
-<link rel="stylesheet" href="http://yui.yahooapis.com/3.5.0/build/cssreset/cssreset-min.css" />
+<link rel="stylesheet" href="https://yui.yahooapis.com/3.5.0/build/cssreset/cssreset-min.css" />
 <style>
 	html {
 		color: #333;


### PR DESCRIPTION
The demo seems to be broken, as it loads libraries via HTTP. So the console will output these errors (as jquery isn't available): [Screenshot](https://i.imgur.com/eX1K0fD.png)

This pull request simply replaces `http` urls with `https`, so that Chrome does not throw errors and loads the files properly as expected.