### PR TITLE
Change http to https for jquery.min.js

### DIFF
--- a/demo/glyflist/index.html
+++ b/demo/glyflist/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <title>ttf.js Demo - Glyph List</title>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script type="text/javascript" src="../../vendor/jdataview.js"></script>
 <script type="text/javascript" src="../../src/ttf.js"></script>
 <script type="text/javascript" src="./glyflist.js"></script>


### PR DESCRIPTION
This should make the tool work in modern browsers that enforce CORS